### PR TITLE
chore: remove Bower version property

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "pouchdb-authentication",
-  "version": "0.5.1",
   "description": "Easy authentication plugin for PouchDB/CouchDB",
   "main": "dist/pouchdb.authentication.js",
   "homepage": "https://github.com/nolanlawson/pouchdb-authentication",


### PR DESCRIPTION
Bower is [supposed to ignore](https://github.com/bower/spec/blob/59c8f0e8f8444cbdd71a091919d28d0fa29d56fe/json.md#version) the version property, but currently still
complains with:

```
bower mismatch      Version declared in the json (0.5.1) is different than the resolved one (0.5.5)
```

Since it infers the version from Git tags, just remove the property altogether.
