### PR TITLE
putUser should allow updating metadata

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ function putUser(db, user, opts, callback) {
         }
       }
     }
-    user = utils.extend(true, user, opts.metadata);
+    user = utils.extend(true, user, opts);
   }
 
   var url = utils.getUsersUrl(db) + '/' + encodeURIComponent(user._id);

--- a/test/test.js
+++ b/test/test.js
@@ -115,8 +115,8 @@ testCases.forEach(function (testCase) {
         return db.getUser('robin');
       }).then(function (user) {
         user.name.should.equal('robin');
-        user.alias.should.equal('boywonder');
-        user.profession.should.equal('acrobat');
+        user.metadata.alias.should.equal('boywonder');
+        user.metadata.profession.should.equal('acrobat');
       });
     });
 
@@ -131,16 +131,16 @@ testCases.forEach(function (testCase) {
         return db.getUser('robin');
       }).then(function (user) {
         user.name.should.equal('robin');
-        user.alias.should.equal('boywonder');
-        user.profession.should.equal('acrobat');
+        user.metadata.alias.should.equal('boywonder');
+        user.metadata.profession.should.equal('acrobat');
       }).then(function () {
         return db.putUser('robin', {metadata: newMetadata});
       }).then(function () {
         return db.getUser('robin');
       }).then(function (user) {
         user.name.should.equal('robin');
-        user.alias.should.equal('rednowyob');
-        user.profession.should.equal('taborca');
+        user.metadata.alias.should.equal('rednowyob');
+        user.metadata.profession.should.equal('taborca');
       });
     });
 


### PR DESCRIPTION
Currently, `db.putUser('username', {metadata: {email: 'foo@bar.com'})` actually sets the user's `email` property instead of the user's `metadata.email` property. It puts the metadata in the root level of the user object. This PR resolves that to match the functionality listed in the docs.
