### PR TITLE
Fix reserved words handling in putUser

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,10 +19,8 @@ function putUser(db, user, opts, callback) {
   var reservedWords = ['name', 'password', 'roles', 'type', 'salt', 'metadata'];
   if (opts.metadata) {
     for (var key in opts.metadata) {
-      if (opts.hasOwnProperty(key)) {
-        if (reservedWords.indexOf(key) !== -1 || key.startsWith('_')) {
-          return callback(new AuthError('cannot use reserved word in metadata: "' + key + '"'));
-        }
+      if (reservedWords.indexOf(key) !== -1 || key.startsWith('_')) {
+        return callback(new AuthError('cannot use reserved word in metadata: "' + key + '"'));
       }
     }
     user = utils.extend(true, user, opts.metadata);

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,10 +16,22 @@ function wrapError(callback) {
 }
 
 function putUser(db, user, opts, callback) {
-  var reservedWords = ['name', 'password', 'roles', 'type', 'salt', 'metadata'];
+  var reservedWords = [
+    '_id',
+    '_rev',
+    'name',
+    'password',
+    'roles',
+    'type',
+    'salt',
+    'derived_key',
+    'password_scheme',
+    'iterations'
+  ];
+
   if (opts.metadata) {
     for (var key in opts.metadata) {
-      if (reservedWords.indexOf(key) !== -1 || key.startsWith('_')) {
+      if (reservedWords.indexOf(key) !== -1) {
         return callback(new AuthError('cannot use reserved word in metadata: "' + key + '"'));
       }
     }


### PR DESCRIPTION
I'm a little confused by the way this was previously being handled, but it seems to me what this is supposed to do is prevent reserved words from being set in `opts.metadata`, not `opts`.

If that's the case, `metadata` is not a reserved word in a CouchDB user document. Also, CouchDB only uses `_id` and `_rev` as underscore-prefixed reserved words. Therefore, explicitly list them and remove the `startsWith` condition in case the user wants to set others.
