### PR TITLE
disable cache for GET auth requests; fixes IE 11 caching issues

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -119,6 +119,7 @@ exports.getSession = utils.toPromise(function (opts, callback) {
 
   var ajaxOpts = utils.extend(true, {
     method : 'GET',
+    cache: false,
     url : url
   }, opts.ajax || {});
   utils.ajax(ajaxOpts, wrapError(callback));
@@ -137,6 +138,7 @@ exports.getUser = utils.toPromise(function (username, opts, callback) {
   var url = utils.getUsersUrl(db);
   var ajaxOpts = utils.extend(true, {
     method : 'GET',
+    cache: false,
     url : url + '/' + encodeURIComponent('org.couchdb.user:' + username)
   }, opts.ajax || {});
   utils.ajax(ajaxOpts, wrapError(callback));


### PR DESCRIPTION
There is a bug with IE 11, caching AJAX GET requests. It is necessary to explicitly disable caching for these requests.