### PR TITLE
(#170) Move to pouchdb-utils' toPromise

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -203,7 +203,8 @@ exports.changePassword = pouchdbUtils.toPromise(function (username, password, op
   });
 });
 
-exports.changeUsername = pouchdbUtils.toPromise(function (oldUsername, newUsername, opts, callback) {
+exports.changeUsername =
+    pouchdbUtils.toPromise(function (oldUsername, newUsername, opts, callback) {
   var db = this;
   var USERNAME_PREFIX = 'org.couchdb.user:';
   var ajax = function (opts) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
-function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+function _interopDefault (ex) {
+  return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex;
+}
 
 var utils = require('./utils');
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,11 @@
 'use strict';
 
+function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+
 var utils = require('./utils');
 
-var Promise = require('pouchdb-promise');
-var pouchdbAjax = require('pouchdb-ajax');
+var Promise = _interopDefault(require('pouchdb-promise'));
+var pouchdbAjax = _interopDefault(require('pouchdb-ajax'));
 var pouchdbUtils = require('pouchdb-utils');
 
 var inherits = require('inherits');

--- a/lib/index.js
+++ b/lib/index.js
@@ -155,7 +155,7 @@ exports.putUser = utils.toPromise(function (username, opts, callback) {
     return callback(new AuthError('You must provide a username'));
   }
 
-  return db.getUser(username, opts, function (error, user) {
+  db.getUser(username, opts, function (error, user) {
     if (error) {
       return callback(error);
     }
@@ -180,7 +180,7 @@ exports.changePassword = utils.toPromise(function (username, password, opts, cal
     return callback(new AuthError('You must provide a password'));
   }
 
-  return db.getUser(username, opts, function (error, user) {
+  db.getUser(username, opts, function (error, user) {
     if (error) {
       return callback(error);
     }
@@ -235,7 +235,7 @@ exports.changeUsername = utils.toPromise(function (oldUsername, newUsername, opt
     return callback(new AuthError('You must provide a username to rename'));
   }
 
-  return db.getUser(newUsername, opts)
+  db.getUser(newUsername, opts)
   .then(function () {
     var error = new AuthError('user already exists');
     error.taken = true;

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,11 +25,11 @@ function putUser(db, user, opts, callback) {
         }
       }
     }
-    user = utils.extend(true, user, opts.metadata);
+    user = utils.assign(user, opts.metadata);
   }
 
   var url = utils.getUsersUrl(db) + '/' + encodeURIComponent(user._id);
-  var ajaxOpts = utils.extend(true, {
+  var ajaxOpts = utils.assign({
     method : 'PUT',
     url : url,
     body : user
@@ -83,7 +83,7 @@ exports.login = utils.toPromise(function (username, password, opts, callback) {
     return callback(new AuthError('you must provide a password'));
   }
 
-  var ajaxOpts = utils.extend(true, {
+  var ajaxOpts = utils.assign({
     method : 'POST',
     url : utils.getSessionUrl(db),
     headers : {'Content-Type': 'application/json'},
@@ -100,7 +100,7 @@ exports.logout = utils.toPromise(function (opts, callback) {
     callback = opts;
     opts = {};
   }
-  var ajaxOpts = utils.extend(true, {
+  var ajaxOpts = utils.assign({
     method : 'DELETE',
     url : utils.getSessionUrl(db)
   }, opts.ajax || {});
@@ -117,7 +117,7 @@ exports.getSession = utils.toPromise(function (opts, callback) {
   }
   var url = utils.getSessionUrl(db);
 
-  var ajaxOpts = utils.extend(true, {
+  var ajaxOpts = utils.assign({
     method : 'GET',
     url : url
   }, opts.ajax || {});
@@ -135,7 +135,7 @@ exports.getUser = utils.toPromise(function (username, opts, callback) {
   }
 
   var url = utils.getUsersUrl(db);
-  var ajaxOpts = utils.extend(true, {
+  var ajaxOpts = utils.assign({
     method : 'GET',
     url : url + '/' + encodeURIComponent('org.couchdb.user:' + username)
   }, opts.ajax || {});
@@ -188,7 +188,7 @@ exports.changePassword = utils.toPromise(function (username, password, opts, cal
     user.password = password;
 
     var url = utils.getUsersUrl(db) + '/' + encodeURIComponent(user._id);
-    var ajaxOpts = utils.extend(true, {
+    var ajaxOpts = utils.assign({
       method : 'PUT',
       url : url,
       body : user
@@ -212,7 +212,7 @@ exports.changeUsername = utils.toPromise(function (oldUsername, newUsername, opt
   };
   var updateUser = function (user, opts) {
     var url = utils.getUsersUrl(db) + '/' + encodeURIComponent(user._id);
-    var updateOpts = utils.extend(true, {
+    var updateOpts = utils.assign({
       method : 'PUT',
       url : url,
       body: user

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,12 @@
 
 var utils = require('./utils');
 
+var Promise = require('pouchdb-promise');
+var pouchdbAjax = require('pouchdb-ajax');
+var pouchdbUtils = require('pouchdb-utils');
+
+var inherits = require('inherits');
+
 function wrapError(callback) {
   // provide more helpful error message
   return function (err, res) {
@@ -25,19 +31,19 @@ function putUser(db, user, opts, callback) {
         }
       }
     }
-    user = utils.assign(user, opts.metadata);
+    user = pouchdbUtils.assign(user, opts.metadata);
   }
 
   var url = utils.getUsersUrl(db) + '/' + encodeURIComponent(user._id);
-  var ajaxOpts = utils.assign({
+  var ajaxOpts = pouchdbUtils.assign({
     method : 'PUT',
     url : url,
     body : user
   }, opts.ajax || {});
-  utils.ajax(ajaxOpts, wrapError(callback));
+  pouchdbAjax(ajaxOpts, wrapError(callback));
 }
 
-exports.signup = utils.toPromise(function (username, password, opts, callback) {
+exports.signup = pouchdbUtils.toPromise(function (username, password, opts, callback) {
   var db = this;
   if (typeof callback === 'undefined') {
     callback = typeof opts === 'undefined' ? (typeof password === 'undefined' ?
@@ -67,7 +73,7 @@ exports.signup = utils.toPromise(function (username, password, opts, callback) {
 
 exports.signUp = exports.signup;
 
-exports.login = utils.toPromise(function (username, password, opts, callback) {
+exports.login = pouchdbUtils.toPromise(function (username, password, opts, callback) {
   var db = this;
   if (typeof callback === 'undefined') {
     callback = opts;
@@ -83,33 +89,33 @@ exports.login = utils.toPromise(function (username, password, opts, callback) {
     return callback(new AuthError('you must provide a password'));
   }
 
-  var ajaxOpts = utils.assign({
+  var ajaxOpts = pouchdbUtils.assign({
     method : 'POST',
     url : utils.getSessionUrl(db),
     headers : {'Content-Type': 'application/json'},
     body : JSON.stringify({name: username, password: password})
   }, opts.ajax || {});
-  utils.ajax(ajaxOpts, wrapError(callback));
+  pouchdbAjax(ajaxOpts, wrapError(callback));
 });
 
 exports.logIn = exports.login;
 
-exports.logout = utils.toPromise(function (opts, callback) {
+exports.logout = pouchdbUtils.toPromise(function (opts, callback) {
   var db = this;
   if (typeof callback === 'undefined') {
     callback = opts;
     opts = {};
   }
-  var ajaxOpts = utils.assign({
+  var ajaxOpts = pouchdbUtils.assign({
     method : 'DELETE',
     url : utils.getSessionUrl(db)
   }, opts.ajax || {});
-  utils.ajax(ajaxOpts, wrapError(callback));
+  pouchdbAjax(ajaxOpts, wrapError(callback));
 });
 
 exports.logOut = exports.logout;
 
-exports.getSession = utils.toPromise(function (opts, callback) {
+exports.getSession = pouchdbUtils.toPromise(function (opts, callback) {
   var db = this;
   if (typeof callback === 'undefined') {
     callback = opts;
@@ -117,14 +123,14 @@ exports.getSession = utils.toPromise(function (opts, callback) {
   }
   var url = utils.getSessionUrl(db);
 
-  var ajaxOpts = utils.assign({
+  var ajaxOpts = pouchdbUtils.assign({
     method : 'GET',
     url : url
   }, opts.ajax || {});
-  utils.ajax(ajaxOpts, wrapError(callback));
+  pouchdbAjax(ajaxOpts, wrapError(callback));
 });
 
-exports.getUser = utils.toPromise(function (username, opts, callback) {
+exports.getUser = pouchdbUtils.toPromise(function (username, opts, callback) {
   var db = this;
   if (typeof callback === 'undefined') {
     callback = typeof opts === 'undefined' ? username : opts;
@@ -135,14 +141,14 @@ exports.getUser = utils.toPromise(function (username, opts, callback) {
   }
 
   var url = utils.getUsersUrl(db);
-  var ajaxOpts = utils.assign({
+  var ajaxOpts = pouchdbUtils.assign({
     method : 'GET',
     url : url + '/' + encodeURIComponent('org.couchdb.user:' + username)
   }, opts.ajax || {});
-  utils.ajax(ajaxOpts, wrapError(callback));
+  pouchdbAjax(ajaxOpts, wrapError(callback));
 });
 
-exports.putUser = utils.toPromise(function (username, opts, callback) {
+exports.putUser = pouchdbUtils.toPromise(function (username, opts, callback) {
   var db = this;
   if (typeof callback === 'undefined') {
     callback = typeof opts === 'undefined' ? username : opts;
@@ -164,7 +170,7 @@ exports.putUser = utils.toPromise(function (username, opts, callback) {
   });
 });
 
-exports.changePassword = utils.toPromise(function (username, password, opts, callback) {
+exports.changePassword = pouchdbUtils.toPromise(function (username, password, opts, callback) {
   var db = this;
   if (typeof callback === 'undefined') {
     callback = typeof opts === 'undefined' ? (typeof password === 'undefined' ?
@@ -188,21 +194,21 @@ exports.changePassword = utils.toPromise(function (username, password, opts, cal
     user.password = password;
 
     var url = utils.getUsersUrl(db) + '/' + encodeURIComponent(user._id);
-    var ajaxOpts = utils.assign({
+    var ajaxOpts = pouchdbUtils.assign({
       method : 'PUT',
       url : url,
       body : user
     }, opts.ajax || {});
-    utils.ajax(ajaxOpts, wrapError(callback));
+    pouchdbAjax(ajaxOpts, wrapError(callback));
   });
 });
 
-exports.changeUsername = utils.toPromise(function (oldUsername, newUsername, opts, callback) {
+exports.changeUsername = pouchdbUtils.toPromise(function (oldUsername, newUsername, opts, callback) {
   var db = this;
   var USERNAME_PREFIX = 'org.couchdb.user:';
   var ajax = function (opts) {
-    return new utils.Promise(function (resolve, reject) {
-      utils.ajax(opts, wrapError(function (err, res) {
+    return new Promise(function (resolve, reject) {
+      pouchdbAjax(opts, wrapError(function (err, res) {
         if (err) {
           return reject(err);
         }
@@ -212,7 +218,7 @@ exports.changeUsername = utils.toPromise(function (oldUsername, newUsername, opt
   };
   var updateUser = function (user, opts) {
     var url = utils.getUsersUrl(db) + '/' + encodeURIComponent(user._id);
-    var updateOpts = utils.assign({
+    var updateOpts = pouchdbUtils.assign({
       method : 'PUT',
       url : url,
       body: user
@@ -244,7 +250,7 @@ exports.changeUsername = utils.toPromise(function (oldUsername, newUsername, opt
     return db.getUser(oldUsername, opts);
   })
   .then(function (user) {
-    var newUser = utils.clone(user);
+    var newUser = pouchdbUtils.clone(user);
     delete newUser._rev;
     newUser._id = USERNAME_PREFIX + newUsername;
     newUser.name = newUsername;
@@ -269,7 +275,7 @@ function AuthError(message) {
   } catch (e) {}
 }
 
-utils.inherits(AuthError, Error);
+inherits(AuthError, Error);
 
 if (typeof window !== 'undefined' && window.PouchDB) {
   window.PouchDB.plugin(exports);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -23,8 +23,6 @@ exports.toPromise = pouchdbUtils.toPromise;
 exports.inherits = require('inherits');
 exports.extend = require('pouchdb-extend');
 exports.ajax = require('pouchdb-ajax');
-exports.clone = function (obj) {
-  return exports.extend(true, {}, obj);
-};
-exports.uuid = require('pouchdb-utils').uuid;
+exports.clone = pouchdbUtils.clone;
+exports.uuid = pouchdbUtils.uuid;
 exports.Promise = Promise;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,7 +21,7 @@ exports.once = pouchdbUtils.once;
 exports.toPromise = pouchdbUtils.toPromise;
 
 exports.inherits = require('inherits');
-exports.extend = require('pouchdb-extend');
+exports.assign = pouchdbUtils.assign;
 exports.ajax = require('pouchdb-ajax');
 exports.clone = pouchdbUtils.clone;
 exports.uuid = pouchdbUtils.uuid;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Promise = require('pouchdb-promise');
+var pouchdbUtils = require('pouchdb-utils');
 var urlJoin = require('url-join');
 
 function getBaseUrl(db) {
@@ -16,74 +17,8 @@ exports.getUsersUrl = function (db) {
 exports.getSessionUrl = function (db) {
   return urlJoin(getBaseUrl(db), '/_session');
 };
-exports.once = function (fun) {
-  var called = false;
-  return exports.getArguments(function (args) {
-    if (called) {
-      console.trace();
-      throw new Error('once called  more than once');
-    } else {
-      called = true;
-      fun.apply(this, args);
-    }
-  });
-};
-exports.getArguments = function (fun) {
-  return function () {
-    var len = arguments.length;
-    var args = new Array(len);
-    var i = -1;
-    while (++i < len) {
-      args[i] = arguments[i];
-    }
-    return fun.call(this, args);
-  };
-};
-exports.toPromise = function (func) {
-  //create the function we will be returning
-  return exports.getArguments(function (args) {
-    var self = this;
-    var tempCB = (typeof args[args.length - 1] === 'function') ? args.pop() : false;
-    // if the last argument is a function, assume its a callback
-    var usedCB;
-    if (tempCB) {
-      // if it was a callback, create a new callback which calls it,
-      // but do so async so we don't trap any errors
-      usedCB = function (err, resp) {
-        process.nextTick(function () {
-          tempCB(err, resp);
-        });
-      };
-    }
-    var promise = new Promise(function (fulfill, reject) {
-      try {
-        var callback = exports.once(function (err, mesg) {
-          if (err) {
-            reject(err);
-          } else {
-            fulfill(mesg);
-          }
-        });
-        // create a callback for this invocation
-        // apply the function in the orig context
-        args.push(callback);
-        func.apply(self, args);
-      } catch (e) {
-        reject(e);
-      }
-    });
-    // if there is a callback, call it back
-    if (usedCB) {
-      promise.then(function (result) {
-        usedCB(null, result);
-      }, usedCB);
-    }
-    promise.cancel = function () {
-      return this;
-    };
-    return promise;
-  });
-};
+exports.once = pouchdbUtils.once;
+exports.toPromise = pouchdbUtils.toPromise;
 
 exports.inherits = require('inherits');
 exports.extend = require('pouchdb-extend');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var Promise = require('pouchdb-promise');
-var pouchdbUtils = require('pouchdb-utils');
 var urlJoin = require('url-join');
 
 function getBaseUrl(db) {
@@ -11,18 +9,10 @@ function getBaseUrl(db) {
     return db.name.replace(/\/[^\/]+\/?$/, '');
   }
 }
+
 exports.getUsersUrl = function (db) {
   return urlJoin(getBaseUrl(db), '/_users');
 };
 exports.getSessionUrl = function (db) {
   return urlJoin(getBaseUrl(db), '/_session');
 };
-exports.once = pouchdbUtils.once;
-exports.toPromise = pouchdbUtils.toPromise;
-
-exports.inherits = require('inherits');
-exports.assign = pouchdbUtils.assign;
-exports.ajax = require('pouchdb-ajax');
-exports.clone = pouchdbUtils.clone;
-exports.uuid = pouchdbUtils.uuid;
-exports.Promise = Promise;

--- a/package.json
+++ b/package.json
@@ -29,10 +29,9 @@
   },
   "dependencies": {
     "inherits": "2.0.1",
-    "pouchdb-ajax": "6.0.3",
-    "pouchdb-extend": "0.1.2",
-    "pouchdb-promise": "6.0.3",
-    "pouchdb-utils": "6.0.3",
+    "pouchdb-ajax": "6.1.1",
+    "pouchdb-promise": "6.1.1",
+    "pouchdb-utils": "6.1.1",
     "url-join": "1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR supersedes #168.

This PR moves current code to use the `toPromise` provided by `pouchdb-utils`.
It also makes some clean in the other utility functions to also make use of `pouchdb-utils`.

- (#170) Use pouchdb-utils module for toPromise and once
    This also removes useless returns in three of the API methods as they
    were used to call callback in the end. Those would break with PouchDB's
    toPromise as it would enforce fulfilling them.

- (#170) Use pouchdb-utils module for clone and uuid

- (#170) Use pouchdb-utils' assign in place of pouchdb-extend
    Also bumps to PouchDB 6.1.1

- (#170) Clean sub-module utils