### PR TITLE
Various fixes to putUser

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,13 +22,23 @@ function wrapError(callback) {
 }
 
 function putUser(db, user, opts, callback) {
-  var reservedWords = ['name', 'password', 'roles', 'type', 'salt', 'metadata'];
+  var reservedWords = [
+    '_id',
+    '_rev',
+    'name',
+    'type',
+    'roles',
+    'password',
+    'password_scheme',
+    'iterations',
+    'derived_key',
+    'salt'
+  ];
+
   if (opts.metadata) {
     for (var key in opts.metadata) {
-      if (opts.hasOwnProperty(key)) {
-        if (reservedWords.indexOf(key) !== -1 || key.startsWith('_')) {
-          return callback(new AuthError('cannot use reserved word in metadata: "' + key + '"'));
-        }
+      if (opts.metadata.hasOwnProperty(key) && reservedWords.indexOf(key) !== -1) {
+        return callback(new AuthError('cannot use reserved word in metadata: "' + key + '"'));
       }
     }
     user = pouchdbUtils.assign(user, opts.metadata);

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,6 +44,10 @@ function putUser(db, user, opts, callback) {
     user = pouchdbUtils.assign(user, opts.metadata);
   }
 
+  if (opts.roles) {
+    user = pouchdbUtils.assign(user, {roles: opts.roles});
+  }
+
   var url = utils.getUsersUrl(db) + '/' + encodeURIComponent(user._id);
   var ajaxOpts = pouchdbUtils.assign({
     method : 'PUT',
@@ -73,7 +77,7 @@ exports.signup = pouchdbUtils.toPromise(function (username, password, opts, call
   var user = {
     name     : username,
     password : password,
-    roles    : opts.roles || [],
+    roles    : [],
     type     : 'user',
     _id      : userId
   };

--- a/test/test.js
+++ b/test/test.js
@@ -211,6 +211,50 @@ testCases.forEach(function (testCase) {
       });
     });
 
+    it('Test that admin can change roles', function () {
+      var roles = ['sidekick'];
+      var newRoles = ['superhero', 'villain'];
+      return db.signup('robin', 'dickgrayson', {roles: roles}).then(function (res) {
+        res.ok.should.equal(true);
+        return db.getUser('robin');
+      }).then(function (user) {
+        user.roles.should.deep.equal(roles);
+      }).then(function () {
+        return db.putUser('robin', {roles: newRoles});
+      }).then(function (res) {
+        res.ok.should.equal(true);
+        return db.getUser('robin');
+      }).then(function (user) {
+        user.roles.should.deep.equal(newRoles);
+      }).catch(function (err) {
+        should.not.exist(err);
+      });
+    });
+
+    it('Test that user cannot change roles', function () {
+      var roles = ['sidekick'];
+      var newRoles = ['superhero', 'villain'];
+      // We can't test for initial roles as we are in admin party
+      // Let us have faith in CouchDB
+      return db.signup('robin', 'dickgrayson', {roles: roles}).then(function (res) {
+        res.ok.should.equal(true);
+        return db.login('robin', 'dickgrayson');
+      }).then(function () {
+        return db.getUser('robin');
+      }).then(function (user) {
+        user.roles.should.deep.equal(roles);
+      }).then(function () {
+        return db.putUser('robin', {roles: newRoles});
+      }).then(function (res) {
+        res.ok.should.not.equal(true);
+        return db.getUser('robin').then(function (user) {
+          user.roles.should.deep.equal(roles);
+        });
+      }).catch(function (err) {
+        should.exist(err);
+      });
+    });
+
     it('Test wrong user for getUser', function () {
       return db.signup('robin', 'dickgrayson').then(function (res) {
         return db.signup('aquaman', 'sleeps_with_fishes');

--- a/test/test.js
+++ b/test/test.js
@@ -22,8 +22,8 @@ testCases.forEach(function (testCase) {
   describe('authentication-' + testCase, function () {
 
     var dbName = testCase === 'normal' ?
-      'http://localhost:5984/testdb' :
-      'http://localhost:5984/testdb/'; // trailing slash
+        'http://localhost:5984/testdb' :
+        'http://localhost:5984/testdb/'; // trailing slash
 
     var db;
 
@@ -141,6 +141,73 @@ testCases.forEach(function (testCase) {
         user.name.should.equal('robin');
         user.alias.should.equal('rednowyob');
         user.profession.should.equal('taborca');
+      });
+    });
+
+    var reservedWords = [
+      '_id',
+      '_rev',
+      'name',
+      'type',
+      'roles',
+      'password',
+      'password_scheme',
+      'iterations',
+      'derived_key',
+      'salt'
+    ];
+
+    reservedWords.forEach(function (key) {
+      it('Test changing metadata using reserved word "' + key + '"', function () {
+        return db.signup('robin', 'dickgrayson').then(function (res) {
+          res.ok.should.equal(true);
+          return db.login('robin', 'dickgrayson');
+        }).then(function () {
+          return db.getUser('robin').then(function (user) {
+            var metadata = {};
+            metadata[key] = 'test';
+            return db.putUser('robin', {metadata: metadata}).then(function (res) {
+              res.ok.should.not.equal(true);
+            }).catch(function (err) {
+              should.exist(err);
+              err.status.should.equal(400);
+              err.name.should.equal('authentication_error');
+              err.message.should.equal('cannot use reserved word in metadata: "' + key + '"');
+              err.error.should.equal(true);
+
+              if (key === 'password') {
+                return db.login('robin', 'dickgrayson').then(function (res) {
+                  res.ok.should.equal(true);
+                }).catch(function (err) {
+                  should.not.exist(err);
+                });
+              } else {
+                return db.getUser('robin').then(function (changedUser) {
+                  changedUser[key].should.deep.equal(user[key]);
+                }).catch(function (err) {
+                  should.not.exist(err);
+                });
+              }
+            });
+          });
+        });
+      });
+    });
+
+    it('Test changing metadata using non-reserved word "metadata"', function () {
+      var metadata = {test: 'test'};
+      return db.signup('robin', 'dickgrayson').then(function (res) {
+        res.ok.should.equal(true);
+        return db.login('robin', 'dickgrayson');
+      }).then(function () {
+        return db.putUser('robin', {metadata: {metadata: metadata}});
+      }).then(function (res) {
+        res.ok.should.equal(true);
+        return db.getUser('robin');
+      }).then(function (changedUser) {
+        changedUser.metadata.should.deep.equal(metadata);
+      }).catch(function (err) {
+        should.not.exist(err);
       });
     });
 


### PR DESCRIPTION
Some fixes to putUser (and its twin signUp):
- fix(putUser): ensure reserved words are enforced in metadata
    BREAKING CHANGE: In both signUp and putUser, '_id', '_rev', 'name',
    'type', 'roles', 'password', 'password_scheme', 'iterations',
    'derived_key', 'salt' are now all reserved words, and 'metadata' is
    not a reserved word anymore.
- feat(putUser): take roles in account
    Closes #114
    Roles can now be modified via putUser by passing ops.roles.

In particular this reimplements the fix of PR #120 from @tlvince, while adding extensive tests.
Also, add the possibility to modify roles through `putUser` (as can be done with `signUp`):
```js
db.putUser(username, {roles: ['superhero'], metadata: {email: 'robin@gotham.us'}});
```