### PR TITLE
(#158) Respect DB prefix for base URL if set

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,6 +5,8 @@ var urlJoin = require('url-join');
 function getBaseUrl(db) {
   if (typeof db.getUrl === 'function') { // pouchdb pre-6.0.0
     return db.getUrl().replace(/\/[^\/]+\/?$/, '');
+  } else if (db.__opts && db.__opts.prefix) { // PouchDB.defaults
+    return db.__opts.prefix;
   } else { // pouchdb post-6.0.0
     return db.name.replace(/\/[^\/]+\/?$/, '');
   }


### PR DESCRIPTION
If [PouchDB.defaults][1] is used, its options are attached to `__.opts`.

In the case of `PouchDB.defaults({prefix: ''})`:

> `prefix` appends a prefix to the database name and can be helpful for
> URL-based or file-based LevelDOWN path names.

For example: `{prefix: 'https://example.com/', name: 'test'}` would
produce a DB "name" of `https://example.com/test`.

Before, prefix was not respected.

Closes #158.
Connects #160.

[1]: https://pouchdb.com/api.html#defaults