### PR TITLE
fix(auth): also use Basic Authentication information database opts

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -28,12 +28,22 @@ function getSessionUrl(db) {
 }
 
 function getBasicAuthHeaders(db) {
-  var url = urlParse(db.name);
-  if (!url.auth) {
+  var auth;
+
+  if (db.__opts.auth) {
+    auth = db.__opts.auth;
+  } else {
+    var url = urlParse(db.name);
+    if (url.auth) {
+      auth = url;
+    }
+  }
+
+  if (!auth) {
     return {};
   }
 
-  var str = url.username + ':' + url.password;
+  var str = auth.username + ':' + auth.password;
   var token = btoa(unescape(encodeURIComponent(str)));
   return {Authorization: 'Basic ' + token};
 }

--- a/test/test.issue.204.js
+++ b/test/test.issue.204.js
@@ -1,0 +1,62 @@
+'use strict';
+
+var PouchDB = require('pouchdb-memory');
+var Authentication = require('../lib');
+PouchDB.plugin(Authentication);
+
+var utils = require('./test-utils');
+var chai = require('chai');
+chai.should();
+
+var serverHost = utils.getConfig().serverHost;
+
+describe('issue-204', function () {
+
+  var dbName = serverHost + '/testdb';
+
+  var db;
+
+  beforeEach(function () {
+    db = new PouchDB(dbName);
+    return utils.ensureUsersDatabaseExists(db).then(function () {
+      return db.signUpAdmin('anna', 'secret');
+    }).then(function () {
+      return db.signup('spiderman', 'will-remember');
+    });
+  });
+
+  afterEach(function () {
+    return db.logIn('anna', 'secret').then(function () {
+      return db.deleteUser('spiderman');
+    }).then(function () {
+      return db.deleteAdmin('anna');
+    }).then(function () {
+      return db.logOut();
+    }).then(function () {
+      return db.destroy();
+    });
+  });
+
+  function testGetUser(db) {
+    return db.getUser('spiderman').then(function (res) {
+      res.name.should.equal('spiderman');
+    });
+  }
+
+  it('Test get user with basic authentication through URL', function () {
+    var dbNameWithAuth = dbName.replace('http://', 'http://spiderman:will-remember@');
+    var dbWithBasicAuth = new PouchDB(dbNameWithAuth, {skip_setup: true});
+    return testGetUser(dbWithBasicAuth);
+  });
+
+  it('Test get user with basic authentication through PouchDB opts', function () {
+    var dbWithBasicAuth = new PouchDB(dbName, {
+      skip_setup: true,
+      auth: {
+        username: 'spiderman',
+        password: 'will-remember',
+      },
+    });
+    return testGetUser(dbWithBasicAuth);
+  });
+});


### PR DESCRIPTION
Previously only Basic Authentication information from url was used.
Now, also information from db.__opts.auth is used.

Fixes #204.