### PR TITLE
* [bug] no default import on ts-es6

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -177,5 +177,5 @@ declare namespace PouchDB {
 
 declare module 'pouchdb-authentication' {
   const plugin: PouchDB.Plugin;
-  export = plugin;
+  export default plugin;
 }


### PR DESCRIPTION
When imported it does not compile and gives me this error.

```ts
import AuthPlugin from 'pouchdb-authentication';
```

TS1192: Module '"/node_modules/pouchdb-authentication"' has no default export.

if you have `export = module` witch is our case and this breaks es6 style syntax
See [Microsoft/TypeScript#2242](https://github.com/Microsoft/TypeScript/issues/2242#issuecomment-83694181).