### PR TITLE
Add instructions for couchdb server with require_valid_user = true

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -99,6 +99,8 @@ db.logIn('superman', 'clarkkent', function (err, response) {
 {"ok":true,"name":"david","roles":[]}
 ```
 
+**Note:** If your couchDB server is configured with `require_valid_user = true`, you must provide credentials in the db constructure as detailed here: https://pouchdb.com/api.html#create_database
+
 #### db.logOut([callback])
 
 Logs out whichever user is currently logged in. If nobody's logged in, it does nothing and just returns `{"ok" : true}`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -99,7 +99,7 @@ db.logIn('superman', 'clarkkent', function (err, response) {
 {"ok":true,"name":"david","roles":[]}
 ```
 
-**Note:** If your couchDB server is configured with `require_valid_user = true`, you must provide credentials in the db constructure as detailed here: https://pouchdb.com/api.html#create_database
+**Note:** If your couchDB server is configured with `require_valid_user = true`, you must provide credentials in the db constructor as detailed here: https://pouchdb.com/api.html#create_database
 
 #### db.logOut([callback])
 


### PR DESCRIPTION
My CouchDB server was configured with `require_valid_user = true`, and I couldn't understand why `pouchdb-authentication` wasn't sending the basic auth headers along with the request to `/_session`.

It wasn't until I started going through the source code that I realized that those headers are only sent if the db was initialized with the `auth` option.

Hopefully this change to the documentation will help others.

Related: #61