### PR TITLE
Make it available for Service Workers too

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,4 +37,9 @@ if (typeof window !== 'undefined' && window.PouchDB) {
   window.PouchDB.plugin(plugin);
 }
 
+// Make it available at service workers too!
+if (self.PouchDB) {
+  self.PouchDB.plugin(plugin);
+}
+  
 export default plugin;


### PR DESCRIPTION
I intended to use this plugin in a service worker and since it checked for `PouchDB` on `window` instance it was not available. 
The `PouchDB`  instance is accessible under the service worker's `ServiceWorkerGlobalScope` though!